### PR TITLE
Cast all data to string to avoid the need of doing it in Excel

### DIFF
--- a/xls2xml.py
+++ b/xls2xml.py
@@ -167,7 +167,7 @@ def _gen_groups(root, groups):
         colname_el = ET.SubElement(root, key)
         for k, v in value.items():
             el = ET.SubElement(colname_el, k)
-            el.text = v
+            el.text = str(v)
 
 
 def _gen_xml_elements0(book, headers, row):


### PR DESCRIPTION
We are using this script in 510 (the section of Netherlands Red Cross working in data and digital transformation) and we find less complicated if the script itself do the cast to string, as Excel does not always save in text by default.
Any comment you can write me here or to the following email addresses:
fsuarezj@gmail.com
FSuarezJimenez@redcross.nl