### PR TITLE
Cast to text to avoid doing it in Excel

### DIFF
--- a/xls2xml.py
+++ b/xls2xml.py
@@ -167,7 +167,7 @@ def _gen_groups(root, groups):
         colname_el = ET.SubElement(root, key)
         for k, v in value.items():
             el = ET.SubElement(colname_el, k)
-            el.text = v
+            el.text = str(v)
 
 
 def _gen_xml_elements0(book, headers, row):

--- a/xls2xml.py
+++ b/xls2xml.py
@@ -205,7 +205,7 @@ def _gen_xml_elements0(book, headers, row):
             _parse_group_data(groups, colname, text0)
         else:
             colname_el = ET.SubElement(root, colname)
-            colname_el.text = text0
+            colname_el.text = str(text0)
 
     _gen_multi_selects(root, multi_selects)
     _gen_groups(root, groups)

--- a/xls2xml.py
+++ b/xls2xml.py
@@ -241,7 +241,7 @@ def _gen_group_detail(book, row, headers, data_sheet0, root):
                                 _parse_multi_select_data(multi_selects, header, text)
                             else:
                                 column_el = ET.SubElement(group_sheetname_el,header)
-                                column_el.text = text
+                                column_el.text = str(text)
 
                         _gen_multi_selects(group_sheetname_el, multi_selects)
 


### PR DESCRIPTION
We are using this script in 510 (the section of Netherlands Red Cross working in data and digital transformation) and we find it less complicated if the script itself does the cast to string, as Excel does not always save in text by default.